### PR TITLE
Ember Camera - Add Live Settable Z Endstop Position

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,13 @@
                             <li class="list-group-item"><span>Z: </span><span id="pos-z">0.0</span></li>
                         </ul>
                         </div>
+                        <div class="row justify-content-center pb-1">
+                            <svg id="bed-map-svg" width="240" height="200" style="display:block;margin:auto;"></svg>
+                            <div class="d-flex justify-content-center gap-3 pt-1" style="font-size:11px;">
+                                <span><svg width="10" height="10"><line x1="0" y1="5" x2="10" y2="5" stroke="#22c55e" stroke-width="1.5"/><line x1="5" y1="0" x2="5" y2="10" stroke="#22c55e" stroke-width="1.5"/></svg> Z-switch</span>
+                                <span><svg width="10" height="10"><circle cx="5" cy="5" r="4" fill="#3b82f6" fill-opacity="0.8"/></svg> Nozzle</span>
+                            </div>
+                        </div>
                     
                         <div class="row">
                         <div class="btn-toolbar justify-content-center" role="toolbar" aria-label="Homing Toolbar">

--- a/index.html
+++ b/index.html
@@ -185,6 +185,15 @@
                             </div>
                         </div>
                         </div>
+                        <div class="row">
+                        <div class="btn-toolbar justify-content-center pt-2" role="toolbar" aria-label="Position Toolbar">
+                            <div class="btn-group btn-group-sm" role="group" aria-label="">
+                            <button type="button" class="btn btn-success border" id="set-endstop-position" title="Set current position as axiscope endstop position">
+                                <i class="bi bi-crosshair2"></i> Set Endstop Position
+                            </button>
+                            </div>
+                        </div>
+                        </div>
                         <div id="BouncePositionBar"></div>
                         <div id="BigPositionBar"></div>
                     </div>

--- a/index.html
+++ b/index.html
@@ -175,14 +175,6 @@
                             <li class="list-group-item"><span>Z: </span><span id="pos-z">0.0</span></li>
                         </ul>
                         </div>
-                        <div class="row justify-content-center pb-1">
-                            <svg id="bed-map-svg" width="240" height="200" style="display:block;margin:auto;"></svg>
-                            <div class="d-flex justify-content-center gap-3 pt-1" style="font-size:11px;">
-                                <span><svg width="10" height="10"><line x1="0" y1="5" x2="10" y2="5" stroke="#22c55e" stroke-width="1.5"/><line x1="5" y1="0" x2="5" y2="10" stroke="#22c55e" stroke-width="1.5"/></svg> Z-switch</span>
-                                <span><svg width="10" height="10"><circle cx="5" cy="5" r="4" fill="#3b82f6" fill-opacity="0.8"/></svg> Nozzle</span>
-                            </div>
-                        </div>
-                    
                         <div class="row">
                         <div class="btn-toolbar justify-content-center" role="toolbar" aria-label="Homing Toolbar">
                             <div class="btn-group btn-group-sm ps-5 pe-5 pb-1" role="group" aria-label="">
@@ -192,17 +184,24 @@
                             </div>
                         </div>
                         </div>
-                        <div class="row">
-                        <div class="btn-toolbar justify-content-center pt-2" role="toolbar" aria-label="Position Toolbar">
-                            <div class="btn-group btn-group-sm" role="group" aria-label="">
-                            <button type="button" class="btn btn-success border" id="set-endstop-position" title="Set current position as axiscope endstop position">
-                                <i class="bi bi-crosshair2"></i> Set Endstop Position
-                            </button>
-                            </div>
-                        </div>
-                        </div>
                         <div id="BouncePositionBar"></div>
                         <div id="BigPositionBar"></div>
+                        <!-- Endstop Position Section -->
+                        <div id="endstop-section" class="mt-2 mb-1 border-top border-secondary pt-2" style="display:none;">
+                            <div class="d-flex align-items-center justify-content-between px-2 pb-1">
+                                <small class="text-secondary fw-semibold text-uppercase" style="font-size:10px;letter-spacing:0.05em;">Z Endstop Position</small>
+                                <button type="button" class="btn btn-success btn-sm" id="set-endstop-position" title="Set current position as axiscope endstop position">
+                                    <i class="bi bi-crosshair2"></i> Set Current Position
+                                </button>
+                            </div>
+                            <div class="d-flex justify-content-center">
+                                <svg id="bed-map-svg" style="display:block;"></svg>
+                            </div>
+                            <div class="d-flex justify-content-center gap-3 pt-1" style="font-size:10px;color:#888;">
+                                <span><svg width="10" height="10"><line x1="0" y1="5" x2="10" y2="5" stroke="#22c55e" stroke-width="1.5"/><line x1="5" y1="0" x2="5" y2="10" stroke="#22c55e" stroke-width="1.5"/></svg> Z-switch</span>
+                                <span><svg width="10" height="10"><circle cx="5" cy="5" r="4" fill="#3b82f6" fill-opacity="0.8"/></svg> Nozzle</span>
+                            </div>
+                        </div>
                     </div>
                     <!-- -------------------------- positioning ------------------- -->
                 </div>

--- a/js/index.js
+++ b/js/index.js
@@ -270,6 +270,39 @@ $(document).ready(function() {
         }
     });
 
+    // Set endstop position button handler
+    $('#set-endstop-position').on('click', function() {
+        const url = printerUrl(printerIp, '/printer/gcode/script?script=' + encodeURIComponent('AXISCOPE_SET_ENDSTOP_POSITION CURRENT=1'));
+        
+        $.get(url)
+            .done(function() {
+                console.log('Set endstop position to current location');
+                // Show success feedback
+                const button = $('#set-endstop-position');
+                const originalText = button.html();
+                button.html('<i class="bi bi-check-circle"></i> Position Set!');
+                button.removeClass('btn-success').addClass('btn-outline-success');
+                
+                setTimeout(function() {
+                    button.html(originalText);
+                    button.removeClass('btn-outline-success').addClass('btn-success');
+                }, 2000);
+            })
+            .fail(function(error) {
+                console.error('Failed to set endstop position:', error);
+                // Show error feedback
+                const button = $('#set-endstop-position');
+                const originalText = button.html();
+                button.html('<i class="bi bi-x-circle"></i> Failed');
+                button.removeClass('btn-success').addClass('btn-danger');
+                
+                setTimeout(function() {
+                    button.html(originalText);
+                    button.removeClass('btn-danger').addClass('btn-success');
+                }, 2000);
+            });
+    });
+
     $('#saveIpBtn').on('click', function() {
         let ip = $('#printerIp').val();
         // Strip http:// or https:// when saving the IP

--- a/js/index.js
+++ b/js/index.js
@@ -48,21 +48,32 @@ function updatePage() {
 }
 
 function updateBedMap(axiscope, axis_min, axis_max, gcode_pos) {
-    if (!axiscope || !axis_min || !axis_max) return;
+    if (!axiscope || !axis_min || !axis_max) {
+        $('#endstop-section').hide();
+        return;
+    }
+    $('#endstop-section').show();
 
-    const svg     = document.getElementById('bed-map-svg');
+    const svg = document.getElementById('bed-map-svg');
     if (!svg) return;
 
-    const pad     = 20;
-    const W       = svg.clientWidth  || 220;
-    const H       = svg.clientHeight || 220;
-    const drawW   = W - pad * 2;
-    const drawH   = H - pad * 2;
+    const pad    = 24;
+    const maxDim = 200; // max pixels for the longer axis
 
     const minX = axis_min[0], maxX = axis_max[0];
     const minY = axis_min[1], maxY = axis_max[1];
     const rangeX = maxX - minX || 1;
     const rangeY = maxY - minY || 1;
+
+    // Scale so the longer axis = maxDim, shorter axis scales proportionally
+    const scale  = maxDim / Math.max(rangeX, rangeY);
+    const W      = Math.round(rangeX * scale) + pad * 2;
+    const H      = Math.round(rangeY * scale) + pad * 2;
+    const drawW  = W - pad * 2;
+    const drawH  = H - pad * 2;
+
+    svg.setAttribute('width',  W);
+    svg.setAttribute('height', H);
 
     // Map a printer coordinate to SVG space (Y axis flipped)
     function toSVG(px, py) {

--- a/js/index.js
+++ b/js/index.js
@@ -20,7 +20,7 @@ function isValidIP(input) {
 }
 
 function updatePage() {
-  $.get(printerUrl(printerIp,"/printer/objects/query?gcode_move&toolhead&toolchanger&quad_gantry_level&stepper_enable"), function(data){
+  $.get(printerUrl(printerIp,"/printer/objects/query?gcode_move&toolhead&toolchanger&quad_gantry_level&stepper_enable&axiscope"), function(data){
     // console.log(printerUrl)
     if (data['result']) {
 
@@ -33,13 +33,117 @@ function updatePage() {
       var tool_number = data['result']['status']['toolchanger']['tool_number'];
       var tools       = data['result']['status']['toolchanger']['tool_numbers'];
 
+      var axis_min    = data['result']['status']['toolhead']['axis_minimum'];
+      var axis_max    = data['result']['status']['toolhead']['axis_maximum'];
+      var axiscope    = data['result']['status']['axiscope'];
+
       updatePositions(positions, gcode_pos);
       updateHoming(homed);
       updateQGL(qgl_done);
       updateMotor(checkActiveStepper(steppers));
       updateTools(tools, tool_number);
+      updateBedMap(axiscope, axis_min, axis_max, gcode_pos);
     }
   });
+}
+
+function updateBedMap(axiscope, axis_min, axis_max, gcode_pos) {
+    if (!axiscope || !axis_min || !axis_max) return;
+
+    const svg     = document.getElementById('bed-map-svg');
+    if (!svg) return;
+
+    const pad     = 20;
+    const W       = svg.clientWidth  || 220;
+    const H       = svg.clientHeight || 220;
+    const drawW   = W - pad * 2;
+    const drawH   = H - pad * 2;
+
+    const minX = axis_min[0], maxX = axis_max[0];
+    const minY = axis_min[1], maxY = axis_max[1];
+    const rangeX = maxX - minX || 1;
+    const rangeY = maxY - minY || 1;
+
+    // Map a printer coordinate to SVG space (Y axis flipped)
+    function toSVG(px, py) {
+        return [
+            pad + ((px - minX) / rangeX) * drawW,
+            pad + ((maxY - py) / rangeY) * drawH
+        ];
+    }
+
+    // Clear and redraw
+    svg.innerHTML = '';
+
+    // Bed boundary
+    const [bx1, by1] = toSVG(minX, maxY);
+    const [bx2, by2] = toSVG(maxX, minY);
+    const bedRect = document.createElementNS('http://www.w3.org/2000/svg', 'rect');
+    bedRect.setAttribute('x', bx1);
+    bedRect.setAttribute('y', by1);
+    bedRect.setAttribute('width', bx2 - bx1);
+    bedRect.setAttribute('height', by2 - by1);
+    bedRect.setAttribute('fill', 'none');
+    bedRect.setAttribute('stroke', '#555');
+    bedRect.setAttribute('stroke-width', '1');
+    svg.appendChild(bedRect);
+
+    // Corner labels
+    function addLabel(text, x, y, anchor) {
+        const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        t.setAttribute('x', x); t.setAttribute('y', y);
+        t.setAttribute('text-anchor', anchor);
+        t.setAttribute('font-size', '8');
+        t.setAttribute('fill', '#888');
+        t.textContent = text;
+        svg.appendChild(t);
+    }
+    addLabel(`${minX},${maxY}`, bx1 + 2,  by1 + 10, 'start');
+    addLabel(`${maxX},${maxY}`, bx2 - 2,  by1 + 10, 'end');
+    addLabel(`${minX},${minY}`, bx1 + 2,  by2 - 3,  'start');
+    addLabel(`${maxX},${minY}`, bx2 - 2,  by2 - 3,  'end');
+
+    // Endstop position marker (green crosshair)
+    if (axiscope.endstop_x !== null && axiscope.endstop_y !== null) {
+        const [ex, ey] = toSVG(axiscope.endstop_x, axiscope.endstop_y);
+        const r = 5;
+
+        const hLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        hLine.setAttribute('x1', ex - r); hLine.setAttribute('y1', ey);
+        hLine.setAttribute('x2', ex + r); hLine.setAttribute('y2', ey);
+        hLine.setAttribute('stroke', '#22c55e'); hLine.setAttribute('stroke-width', '1.5');
+        svg.appendChild(hLine);
+
+        const vLine = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+        vLine.setAttribute('x1', ex); vLine.setAttribute('y1', ey - r);
+        vLine.setAttribute('x2', ex); vLine.setAttribute('y2', ey + r);
+        vLine.setAttribute('stroke', '#22c55e'); vLine.setAttribute('stroke-width', '1.5');
+        svg.appendChild(vLine);
+
+        const endLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        endLabel.setAttribute('x', ex + 6); endLabel.setAttribute('y', ey - 4);
+        endLabel.setAttribute('font-size', '8'); endLabel.setAttribute('fill', '#22c55e');
+        endLabel.textContent = `Z-switch (${axiscope.endstop_x.toFixed(1)}, ${axiscope.endstop_y.toFixed(1)})`;
+        svg.appendChild(endLabel);
+    }
+
+    // Current nozzle position marker (blue dot)
+    if (gcode_pos) {
+        const [cx, cy] = toSVG(gcode_pos[0], gcode_pos[1]);
+
+        const dot = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+        dot.setAttribute('cx', cx); dot.setAttribute('cy', cy);
+        dot.setAttribute('r', '4');
+        dot.setAttribute('fill', '#3b82f6');
+        dot.setAttribute('fill-opacity', '0.8');
+        svg.appendChild(dot);
+
+        const posLabel = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+        posLabel.setAttribute('x', cx + 6); posLabel.setAttribute('y', cy + 4);
+        posLabel.setAttribute('font-size', '8'); posLabel.setAttribute('fill', '#3b82f6');
+        posLabel.textContent = `(${gcode_pos[0].toFixed(1)}, ${gcode_pos[1].toFixed(1)})`;
+        svg.appendChild(posLabel);
+    }
 }
 
 function updatePositions(positions, gcode_pos){

--- a/klippy/extras/axiscope.py
+++ b/klippy/extras/axiscope.py
@@ -61,6 +61,7 @@ class Axiscope:
         self.gcode.register_command('AXISCOPE_FINISH_GCODE', self.cmd_AXISCOPE_FINISH_GCODE, desc="Execute the Axiscope finish G-code macro")
         self.gcode.register_command('AXISCOPE_SAVE_TOOL_OFFSET',          self.cmd_AXISCOPE_SAVE_TOOL_OFFSET,          desc=self.cmd_AXISCOPE_SAVE_TOOL_OFFSET_help)
         self.gcode.register_command('AXISCOPE_SAVE_MULTIPLE_TOOL_OFFSETS', self.cmd_AXISCOPE_SAVE_MULTIPLE_TOOL_OFFSETS, desc=self.cmd_AXISCOPE_SAVE_MULTIPLE_TOOL_OFFSETS_help)
+        self.gcode.register_command('AXISCOPE_SET_ENDSTOP_POSITION', self.cmd_AXISCOPE_SET_ENDSTOP_POSITION, desc=self.cmd_AXISCOPE_SET_ENDSTOP_POSITION_help)
 
     def handle_connect(self):
         if self.config_file_path is not None:
@@ -368,6 +369,67 @@ class Axiscope:
 
         else:
             gcmd.respond_info("Axiscope needs a valid config location (config_file_path) to save tool offsets.")
+
+    cmd_AXISCOPE_SET_ENDSTOP_POSITION_help = "Set kinematic position for X, Y, and/or Z axes"
+    
+    def cmd_AXISCOPE_SET_ENDSTOP_POSITION(self, gcmd):
+        """
+        Set axiscope endstop positions for specified axes. Can receive X, Y, and/or Z optionally.
+        
+        Usage
+        -----
+        AXISCOPE_SET_ENDSTOP_POSITION [X=<x_pos>] [Y=<y_pos>] [Z=<z_pos>] [CURRENT=<1|0>]
+        
+        Examples
+        --------
+        AXISCOPE_SET_ENDSTOP_POSITION X=150.0          # Set only X endstop position
+        AXISCOPE_SET_ENDSTOP_POSITION Y=200.0          # Set only Y endstop position  
+        AXISCOPE_SET_ENDSTOP_POSITION Z=0.0            # Set only Z endstop position
+        AXISCOPE_SET_ENDSTOP_POSITION X=150.0 Y=200.0  # Set X and Y endstop positions
+        AXISCOPE_SET_ENDSTOP_POSITION X=150.0 Y=200.0 Z=0.0  # Set all endstop positions
+        AXISCOPE_SET_ENDSTOP_POSITION CURRENT=1        # Set all positions to current position
+        AXISCOPE_SET_ENDSTOP_POSITION X=150.0 CURRENT=1  # Set X to 150.0, Y and Z to current
+        """
+        # Get current position
+        toolhead = self.printer.lookup_object('toolhead')
+        current_pos = toolhead.get_position()
+        
+        # Check if CURRENT parameter is set
+        use_current = gcmd.get_int('CURRENT', 0)
+        
+        # Get optional parameters
+        x_pos = gcmd.get_float('X', None)
+        y_pos = gcmd.get_float('Y', None) 
+        z_pos = gcmd.get_float('Z', None)
+        
+        # If CURRENT=1, use current position for unspecified axes
+        if use_current:
+            if x_pos is None:
+                x_pos = current_pos[0]
+            if y_pos is None:
+                y_pos = current_pos[1]
+            if z_pos is None:
+                z_pos = current_pos[2]
+        
+        # Update axiscope's internal position variables
+        set_axes = []
+        if x_pos is not None:
+            self.x_pos = x_pos
+            set_axes.append(f"X={x_pos:.3f}")
+        if y_pos is not None:
+            self.y_pos = y_pos
+            set_axes.append(f"Y={y_pos:.3f}")
+        if z_pos is not None:
+            self.z_pos = z_pos
+            set_axes.append(f"Z={z_pos:.3f}")
+            
+        if set_axes:
+            if use_current:
+                gcmd.respond_info(f"Set axiscope endstop positions (using current): {' '.join(set_axes)}")
+            else:
+                gcmd.respond_info(f"Set axiscope endstop positions: {' '.join(set_axes)}")
+        else:
+            gcmd.respond_info("No axes specified. Use X=, Y=, Z=, and/or CURRENT=1 parameters.")
 
 def load_config(config):
     return Axiscope(config)

--- a/klippy/extras/axiscope.py
+++ b/klippy/extras/axiscope.py
@@ -84,10 +84,7 @@ class Axiscope:
     def get_status(self, eventtime):
         return {
             'probe_results':   self.probe_results,
-            'can_save_config': self.has_cfg_data is not False,
-            'endstop_x':       self.x_pos,
-            'endstop_y':       self.y_pos,
-            'endstop_z':       self.z_pos,
+            'can_save_config': self.has_cfg_data is not False
         }
         
     def run_gcode(self, name, template, extra_context):

--- a/klippy/extras/axiscope.py
+++ b/klippy/extras/axiscope.py
@@ -84,7 +84,10 @@ class Axiscope:
     def get_status(self, eventtime):
         return {
             'probe_results':   self.probe_results,
-            'can_save_config': self.has_cfg_data is not False
+            'can_save_config': self.has_cfg_data is not False,
+            'endstop_x':       self.x_pos,
+            'endstop_y':       self.y_pos,
+            'endstop_z':       self.z_pos,
         }
         
     def run_gcode(self, name, template, extra_context):


### PR DESCRIPTION
New macro available.
UI will use `AXISCOPE_SET_ENDSTOP_POSITION CURRENT=1`

Set axiscope endstop positions for specified axes. Can receive X, Y, and/or Z optionally.

Usage
-----
AXISCOPE_SET_ENDSTOP_POSITION [X=<x_pos>] [Y=<y_pos>] [Z=<z_pos>] [CURRENT=<1|0>]

Examples
--------
AXISCOPE_SET_ENDSTOP_POSITION X=150.0          # Set only X endstop position
AXISCOPE_SET_ENDSTOP_POSITION Y=200.0          # Set only Y endstop position  
AXISCOPE_SET_ENDSTOP_POSITION Z=0.0            # Set only Z endstop position
AXISCOPE_SET_ENDSTOP_POSITION X=150.0 Y=200.0  # Set X and Y endstop positions
AXISCOPE_SET_ENDSTOP_POSITION X=150.0 Y=200.0 Z=0.0  # Set all endstop positions
AXISCOPE_SET_ENDSTOP_POSITION CURRENT=1        # Set all positions to current position
AXISCOPE_SET_ENDSTOP_POSITION X=150.0 CURRENT=1  # Set X to 150.0, Y and Z to current